### PR TITLE
Fix deprecation notice

### DIFF
--- a/src/PBergman/Console/Helper/TreeHelper.php
+++ b/src/PBergman/Console/Helper/TreeHelper.php
@@ -119,7 +119,7 @@ class TreeHelper
      * @param array $format
      * @internal
      */
-    protected static function render(array $data, $prefix = '', array $format, $maxDepth = null, $depth = 0)
+    protected static function render(array $data, $prefix, array $format, $maxDepth = null, $depth = 0)
     {
         if (!is_null($maxDepth) && $maxDepth <= $depth) {
             return;


### PR DESCRIPTION
This fixes the following deprecation notice:

> Deprecated: Optional parameter $prefix declared before required parameter $format is implicitly treated as a required parameter in /path/to/project/vendor/pbergman/tree-helper/src/PBergman/Console/Helper/TreeHelper.php on line 122

Because this method is marked as `@internal` and all usages provide a parameter value, this change should be safe to make in a minor or patch version update.